### PR TITLE
Update Download.vue

### DIFF
--- a/src/views/modules/tunnels/Download.vue
+++ b/src/views/modules/tunnels/Download.vue
@@ -48,12 +48,7 @@ links.value = [
     {
         name: 'Windows 图形启动器',
         arch: 'amd64',
-        url: 'http://cdn.114514.space/Download/Files/MirrorEdge/Mirror_Edge_Frp_Python_Win.zip',
-    },
-    {
-        name: 'Linux 图形启动器',
-        arch: 'amd64',
-        url: 'http://cdn.114514.space/Download/Files/MirrorEdge/Mirror_Edge_Frp_Python_Lin.tar.gz',
+        url: 'https://mefrp-kingc.lanzouv.com/iMxdt0fxavej',
     },
     {
         name: 'Windows',


### PR DESCRIPTION
更新 Download.vue 文件

更换链接为蓝奏云链接
并删除了 Linux客户端下载地址（因为做的实在是太烂了